### PR TITLE
Fix typo in appendix A

### DIFF
--- a/docs/source/Appendix_A.md
+++ b/docs/source/Appendix_A.md
@@ -549,7 +549,7 @@ attribute properties.
 1. Schema attributes with the `boolProperty`  have a `<name>` node but no 
 `<value>` node in the XML.
 Presence indicates true.
-2. Schema attributes with the `boolProperty`  have both `<name>` and 
+2. Schema attributes without the `boolProperty`  have both `<name>` and 
 `<value>` nodes in the XML.
 
 ````


### PR DESCRIPTION
The tip in section A.3.1 incorrectly stated that schema attributes with `boolProperty` both had and didn't have values. This commit fixes that error by stating that values are required for attributes without `boolProperty`.